### PR TITLE
Feature/programmatic customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,5 @@ Works best with [Spring Boot](https://github.com/spring-projects/spring-boot), i
 
 Related issues:
 -   [spring-framework/pull/1506](https://github.com/spring-projects/spring-framework/pull/1506)
+-   [spring-framework/pull/1932](https://github.com/spring-projects/spring-framework/pull/1932/files)
 -   [spring-boot/issues/9301](https://github.com/spring-projects/spring-boot/issues/9301)

--- a/src/main/java/io/github/stepio/cache/caffeine/CaffeineSupplier.java
+++ b/src/main/java/io/github/stepio/cache/caffeine/CaffeineSupplier.java
@@ -1,11 +1,17 @@
 package io.github.stepio.cache.caffeine;
 
 import com.github.benmanes.caffeine.cache.Caffeine;
+import com.github.benmanes.caffeine.cache.CaffeineSpec;
 import org.springframework.context.EnvironmentAware;
 import org.springframework.core.env.Environment;
 import org.springframework.util.StringUtils;
 
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.function.Function;
+
+import static org.springframework.util.Assert.hasText;
+import static org.springframework.util.Assert.notNull;
 
 /**
  * Supplier for {@link Caffeine} instances, constructed from {@link com.github.benmanes.caffeine.cache.CaffeineSpec} values.
@@ -17,11 +23,27 @@ public class CaffeineSupplier implements Function<String, Caffeine<Object, Objec
 
     private static final String CACHE_SPEC_CUSTOM = "coffee-boots.cache.spec.%s";
 
-    private Environment environment;
+    protected Environment environment;
+    protected final ConcurrentMap<String, Caffeine<Object, Object>> cacheBuilders = new ConcurrentHashMap<>(16);
 
     @Override
     public void setEnvironment(Environment environment) {
         this.environment = environment;
+    }
+
+    public void putCaffeine(String name, Caffeine<Object, Object> caffeine) {
+        notNull(caffeine, "Non-null Caffeine is mandatory");
+        this.cacheBuilders.put(name, caffeine);
+    }
+
+    public void putCaffeineSpec(String name, CaffeineSpec caffeineSpec) {
+        notNull(caffeineSpec, "Non-null Caffeine specification is mandatory");
+        putCaffeine(name, Caffeine.from(caffeineSpec));
+    }
+
+    public void putCaffeineSpecification(String name, String caffeineSpec) {
+        hasText(caffeineSpec, "Non-empty Caffeine specification is mandatory");
+        putCaffeineSpec(name, CaffeineSpec.parse(caffeineSpec));
     }
 
     @Override
@@ -30,7 +52,7 @@ public class CaffeineSupplier implements Function<String, Caffeine<Object, Objec
         if (StringUtils.hasText(value)) {
             return Caffeine.from(value);
         }
-        return null;
+        return cacheBuilders.get(name);
     }
 
     protected String composeKey(String name) {

--- a/src/test/java/io/github/stepio/cache/caffeine/MultiConfigurationCacheManagerCustomCaffeineTest.java
+++ b/src/test/java/io/github/stepio/cache/caffeine/MultiConfigurationCacheManagerCustomCaffeineTest.java
@@ -1,0 +1,85 @@
+package io.github.stepio.cache.caffeine;
+
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringBootTest(classes = {MultiConfigurationCacheManagerCustomCaffeineTest.TestContext.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
+public class MultiConfigurationCacheManagerCustomCaffeineTest {
+
+    @Autowired
+    private CaffeineSupplier caffeineSupplier;
+    @Autowired
+    private CachedDataHolder cachedDataHolder;
+
+    @Before
+    public void setUp() {
+        Caffeine<Object, Object> custom = Caffeine.<Object, Object>newBuilder()
+                .expireAfterWrite(200L, TimeUnit.MILLISECONDS)
+                .maximumSize(5L);
+        this.caffeineSupplier.putCaffeine("custom", custom);
+        this.caffeineSupplier.putCaffeineSpecification("largeShort", "maximumSize=1000,expireAfterWrite=1h");
+    }
+
+    @Test
+    public void testCreateNativeCaffeineCacheWithCustomCaches() {
+        Object aCustom = this.cachedDataHolder.newCachedCustomObject();
+        assertThat(this.cachedDataHolder.newCachedCustomObject()).isSameAs(aCustom);
+
+        final Object etalon = aCustom;
+        await().atMost(300, TimeUnit.MILLISECONDS)
+                .until(() -> this.cachedDataHolder.newCachedCustomObject() != etalon);
+
+        aCustom = this.cachedDataHolder.newCachedCustomObject();
+        assertThat(this.cachedDataHolder.newCachedCustomObject()).isSameAs(aCustom);
+    }
+
+    @Test
+    public void testCreateNativeCaffeineCacheWithPreconfiguredCachesIgnoreCustom() {
+        Object aShortTerm = this.cachedDataHolder.newCachedShortTermObject();
+        assertThat(this.cachedDataHolder.newCachedShortTermObject()).isSameAs(aShortTerm);
+
+        final Object etalon = aShortTerm;
+        await().atMost(2100, TimeUnit.MILLISECONDS)
+                .until(() -> this.cachedDataHolder.newCachedShortTermObject() != etalon);
+
+        assertThat(this.cachedDataHolder.newCachedShortTermObject()).isNotSameAs(aShortTerm);
+    }
+
+    @SpringBootApplication
+    @EnableCaching
+    static class TestContext {
+
+        @Bean
+        public CachedDataHolder cachedDataHolder() {
+            return new CachedDataHolder();
+        }
+    }
+
+    private static class CachedDataHolder {
+
+        @Cacheable("custom")
+        public Object newCachedCustomObject() {
+            return new Object();
+        }
+
+        @Cacheable("largeShort")
+        public Object newCachedShortTermObject() {
+            return new Object();
+        }
+    }
+}

--- a/src/test/java/io/github/stepio/cache/caffeine/MultiConfigurationCacheManagerNoCaffeineSupplierTest.java
+++ b/src/test/java/io/github/stepio/cache/caffeine/MultiConfigurationCacheManagerNoCaffeineSupplierTest.java
@@ -13,8 +13,11 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringJUnit4ClassRunner.class)
-@SpringBootTest(classes = {CaffeineSpecSpringAutoConfigurationTest.TestContext.class}, webEnvironment = SpringBootTest.WebEnvironment.NONE)
-public class CaffeineSpecSpringAutoConfigurationTest {
+@SpringBootTest(
+        classes = {MultiConfigurationCacheManagerNoCaffeineSupplierTest.TestContext.class},
+        webEnvironment = SpringBootTest.WebEnvironment.NONE
+)
+public class MultiConfigurationCacheManagerNoCaffeineSupplierTest {
 
     @Autowired
     private MultiConfigurationCacheManager cacheManager;


### PR DESCRIPTION
Support programmatic customization of caches.

Allow configuring custom `Caffeine` instances per cache name not only through specifications in properties, but also by invoking the appropriate `put*` method on `CaffeineSupplier` bean.