### PR TITLE
Default spec not used when specific cache spec is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ coffee-boots.cache.spec.myCache=maximumSize=100000,expireAfterWrite=1m
 
 More information is in [issue#44](https://github.com/stepio/coffee-boots/issues/44) or [commit#a134dc6](https://github.com/stepio/coffee-boots/commit/a134dc60843b46b6a69b00ce4449c510b301f534#diff-798aa55948ec42d85da39f34a917b73f).
 
-7.  Use `coffee-boots.cache.default-spec` to define "basic" cache configuration with common key-value pairs to be reused by all other custom cache configurations. This allows simplifying custom configurations if necessary.
+7.  Use `coffee-boots.cache.basic-spec` to define "basic" cache configuration with common key-value pairs to be reused by all other custom cache configurations. This allows simplifying custom configurations if necessary.
 
 More information is in [issue#43](https://github.com/stepio/coffee-boots/issues/43) or [commit#2a38d5b](https://github.com/stepio/coffee-boots/commit/2a38d5b3ca7e12c2cbc152e2b5f5bf0aa3233f34#diff-a6f66d25e49c3ad808097932be3df2d0).
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ More information is in [issue#44](https://github.com/stepio/coffee-boots/issues/
 
 More information is in [issue#43](https://github.com/stepio/coffee-boots/issues/43) or [commit#2a38d5b](https://github.com/stepio/coffee-boots/commit/2a38d5b3ca7e12c2cbc152e2b5f5bf0aa3233f34#diff-a6f66d25e49c3ad808097932be3df2d0).
 
-8.  If you'd like to get automatic metrics registaration for your custom caches, don't forget to add next dependencies:
+8.  If you'd like to get automatic metrics registration for your custom caches, don't forget to add next dependencies:
 
 ```xml
 <dependency>

--- a/src/main/java/io/github/stepio/cache/caffeine/CaffeineSpecResolver.java
+++ b/src/main/java/io/github/stepio/cache/caffeine/CaffeineSpecResolver.java
@@ -29,7 +29,6 @@ public class CaffeineSpecResolver implements EnvironmentAware {
 
     public String getCaffeineSpec(String name) {
         String custom = this.environment.getProperty(composeKey(name));
-
         String basic = this.environment.getProperty(CACHE_BASIC_SPEC);
         if (StringUtils.hasText(basic)) {
             return mergeSpecs(basic, custom);

--- a/src/main/java/io/github/stepio/cache/caffeine/CaffeineSpecResolver.java
+++ b/src/main/java/io/github/stepio/cache/caffeine/CaffeineSpecResolver.java
@@ -29,9 +29,7 @@ public class CaffeineSpecResolver implements EnvironmentAware {
 
     public String getCaffeineSpec(String name) {
         String custom = this.environment.getProperty(composeKey(name));
-        if (StringUtils.isEmpty(custom)) {
-            return null;
-        }
+
         String basic = this.environment.getProperty(CACHE_BASIC_SPEC);
         if (StringUtils.hasText(basic)) {
             return mergeSpecs(basic, custom);
@@ -46,7 +44,9 @@ public class CaffeineSpecResolver implements EnvironmentAware {
     protected static String mergeSpecs(String... specs) {
         Map<String, String> merged = new HashMap<>();
         for (String spec : specs) {
-            merged.putAll(split(spec));
+            if (!StringUtils.isEmpty(spec)) {
+                merged.putAll(split(spec));
+            }
         }
         return join(merged);
     }

--- a/src/test/java/io/github/stepio/cache/caffeine/CaffeineSpecResolverTest.java
+++ b/src/test/java/io/github/stepio/cache/caffeine/CaffeineSpecResolverTest.java
@@ -58,7 +58,7 @@ public class CaffeineSpecResolverTest {
     }
 
     @Test
-    public void testGetCaffeineSpecNotDefined() {
+    public void testGetCaffeineSpecWhenDefaultNotDefined() {
         doReturn(null)
                 .when(this.environment)
                 .getProperty(eq(CACHE_BASIC_SPEC));
@@ -76,6 +76,12 @@ public class CaffeineSpecResolverTest {
                 .contains("expireAfterWrite=7m");
         assertThat(this.caffeineSpecResolver.getCaffeineSpec("full"))
                 .contains("maximumSize=5000", "expireAfterWrite=12h", ",");
+    }
+
+    @Test
+    public void testGetCaffeineSpecWhenNotDefinedAndDefaultDefined() {
+        assertThat(this.caffeineSpecResolver.getCaffeineSpec("unspecifiedSpec"))
+                .contains("maximumSize=100");
     }
 
     @Test

--- a/src/test/java/io/github/stepio/cache/caffeine/CaffeineSpecResolverTest.java
+++ b/src/test/java/io/github/stepio/cache/caffeine/CaffeineSpecResolverTest.java
@@ -58,7 +58,7 @@ public class CaffeineSpecResolverTest {
     }
 
     @Test
-    public void testGetCaffeineSpecWhenDefaultNotDefined() {
+    public void testGetCaffeineSpecNotDefined() {
         doReturn(null)
                 .when(this.environment)
                 .getProperty(eq(CACHE_BASIC_SPEC));


### PR DESCRIPTION
Thanks for creating this library, @stepio. We're leveraging and loving it very much. 

This change is to fix a situation where a specific cache name spec is not defined and the default spec string is not being used for that cache name. We came across that issue when running it in production and our cache size was growing indefinitely.